### PR TITLE
add fiber support for all BDD helpers - fixes #70

### DIFF
--- a/lib/interface.js
+++ b/lib/interface.js
@@ -35,30 +35,18 @@ Mocha.interfaces['gagarin'] = module.exports = function (suite) {
 
     // adding Fiber support
     context.Fiber = Fiber;
-    var originalIt = context.it;
-    context.it = function(name, test) {
-      if (test) {
-        originalIt(name, function(done) {
-          new Fiber(function() {
-            if (test.length > 0) {
-              test(done);
-            } else {
-              var promise = test();
-              if (promise) {
-                promiseAsThunk(promise)(done);
-              } else {
-                done();
-              }
-            }
-          }).run();
-        });
-      } else {
-        originalIt(name);
-      }
-    };
 
-    context.it.skip = originalIt.skip;
-    context.it.only = originalIt.only;
+    var originalIt = context.it;
+    context.it = runInsideFiber(context.it);
+    context.it.skip = runInsideFiber(originalIt.skip);
+    context.it.only = runInsideFiber(originalIt.only);
+    context.specify = context.it;
+    context.xspecify = context.xit = context.it.skip;
+
+    context.before = runInsideFiber(context.before);
+    context.beforeEach = runInsideFiber(context.beforeEach);
+    context.after = runInsideFiber(context.after);
+    context.afterEach = runInsideFiber(context.afterEach);
 
     context.expect = require('chai').expect;
 
@@ -174,20 +162,17 @@ Mocha.interfaces['gagarin'] = module.exports = function (suite) {
     };
 
     context.settings = JSON.parse(JSON.stringify(gagarin_settings)); // deep copy :P
-
-    //context.wait = wait;
   });
-
 }
 
 function wrapPromisesForFiber(obj, methodList) {
   var proxy = {};
-  
+
   methodList.forEach(function(method) {
     var original = obj[method];
     proxy[method] = function() {
       var f = new Future();
-      
+
       var promise = original.apply(obj, arguments);
       promiseAsThunk(promise)(function(error, value) {
         if (error) {
@@ -213,30 +198,32 @@ function promiseAsThunk(promise, done) {
   };
 }
 
-/*
-function wait(timeout, message, func, args) {
-  "use strict";
+function runInsideFiber (originalFunction) {
+  var fiberizeFunction = function(name, fn) {
+    if (typeof name == "function") {
+      fn = name;
+      name = null;
+    }
 
-  return new Promise(function (resolve, reject) {
-    var handle = null;
-    (function test() {
-      var result;
-      try {
-        result = func.apply(null, args);
-        if (result) {
-          resolve(result);
-        } else {
-          handle = setTimeout(test, 50); // repeat after 1/20 sec.
-        }
-      } catch (err) {
-        reject(err);
-      }
-    }());
-    setTimeout(function () {
-      clearTimeout(handle);
-      reject(new Error('I have been waiting for ' + timeout + ' ms ' + message + ', but it did not happen.'));
-    }, timeout);
-  });
+    if (fn) {
+      originalFunction(name, function(done) {
+        new Fiber(function() {
+          if (fn.length > 0) {
+            fn(done);
+          } else {
+            var promise = fn();
+            if (promise) {
+              promiseAsThunk(promise)(done);
+            } else {
+              done();
+            }
+          }
+        }).run();
+      });
+    } else {
+      originalFunction(name);
+    }
+  };
+
+  return fiberizeFunction;
 }
-*/
-

--- a/tests/specs/flavor.js
+++ b/tests/specs/flavor.js
@@ -27,7 +27,7 @@ describe('Flavor', function () {
         expect(value).to.be.equal(30);
       })
     });
-    
+
     it('still supports promise api with done', function (done) {
       // return a promise
       promiseServer.execute(function () {
@@ -58,7 +58,7 @@ describe('Flavor', function () {
         expect(value).to.be.equal(30);
       })
     });
-    
+
     it('still supports promise api with done', function (done) {
       // return a promise
       promiseBrowser.execute(function () {
@@ -70,4 +70,80 @@ describe('Flavor', function () {
       });
     });
   })
+
+  describe('sync api inside helpers', function() {
+    var beforeK = 0;
+    describe('before', function() {
+      before(function() {
+        beforeK = fiberServer.execute(function() {
+          return 12;
+        });
+      });
+
+      it('should get the value set by before', function() {
+        expect(beforeK).to.be.equal(12);
+      });
+    });
+
+    describe('beforeEach', function() {
+      var beforeY = 0;
+      beforeEach(function() {
+        beforeY = fiberServer.execute(function(beforeY) {
+          return beforeY + 10;
+        }, beforeY);
+      });
+
+      it('should get the value incremented by beforeEach', function() {
+        expect(beforeY).to.be.equal(10);
+      });
+
+      it('should again get the value incremented by beforeEach', function() {
+        expect(beforeY).to.be.equal(20);
+      });
+    });
+
+    describe('afterEach', function() {
+      var beforeA = 0;
+      afterEach(function() {
+        beforeA = fiberServer.execute(function(beforeA) {
+          return beforeA + 10;
+        }, beforeA);
+      });
+
+      it('should not get the value set by afterEach', function() {
+        expect(beforeA).to.be.equal(0);
+      });
+
+      it('should get the value set by afterEach', function() {
+        expect(beforeA).to.be.equal(10);
+      });
+
+      it('should again get the value set by afterEach', function() {
+        expect(beforeA).to.be.equal(20);
+      });
+    });
+
+    describe('after', function() {
+      beforeB = 0;
+      after(function() {
+        beforeB = fiberServer.execute(function(beforeB) {
+          return beforeB + 10;
+        }, beforeB);
+      });
+
+      it('should not get the value set by after', function() {
+        expect(beforeB).to.be.equal(0);
+      });
+
+      it('still should not get the value set by after', function() {
+        expect(beforeB).to.be.equal(0);
+      });
+    });
+
+    describe('checking previous after', function() {
+      it('should get the value set by previous after', function() {
+        expect(beforeB).to.be.equal(10);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Added fiber support for 

* after
* afterEach
* before
* beforeEach
* it.skip
* it.only
* specify
* xspecify
* xit