### PR TITLE
Helper Tests

### DIFF
--- a/lib/browser/helpers.js
+++ b/lib/browser/helpers.js
@@ -22,7 +22,11 @@ module.exports = {
   waitUntilNotVisible: function (selector, timeout) {
     return this.wait(timeout || DEFAULT_TIMEOUT, 'until element ' + selector + ' is hidden', function (selector) {
       var element = document.querySelector(selector);
-      return !element || window.getComputedStyle(element).display === 'none';
+      if(!!element){
+        return element.offsetWidth <= 0 && element.offsetHeight <= 0;
+      }else{
+        return false;
+      }
     }, [ selector ]);
   },
 

--- a/lib/browser/helpers.js
+++ b/lib/browser/helpers.js
@@ -167,7 +167,7 @@ module.exports = {
   disconnect: function () {
     return this.execute(function () {
       Meteor.disconnect();
-    }).wait(1000, 'unitl Meteor disconnects', function () {
+    }).wait(1000, 'until Meteor disconnects', function () {
       return !Meteor.status().connected;
     });
   },
@@ -175,7 +175,7 @@ module.exports = {
   reconnect: function () {
     return this.execute(function () {
       Meteor.reconnect();
-    }).wait(1000, 'unitl Meteor reconnects', function () {
+    }).wait(1000, 'until Meteor reconnects', function () {
       return Meteor.status().connected;
     });
   },

--- a/lib/browser/helpers.js
+++ b/lib/browser/helpers.js
@@ -206,7 +206,11 @@ module.exports = {
   checkIfVisible: function (selector) {
     return this.execute(function (selector) {
       var element = document.querySelector(selector);
-      return !!element && window.getComputedStyle(element).display !== 'none';
+      if(!!element){
+        return element.offsetWidth > 0 && element.offsetHeight > 0;
+      }else{
+        return false;
+      }
     }, [ selector ]);
   },
 

--- a/lib/browser/helpers.js
+++ b/lib/browser/helpers.js
@@ -1,8 +1,9 @@
 var expect = require('chai').expect;
 var either = require('../tools').either;
 var Promise = require('es6-promise').Promise;
-
 var DEFAULT_TIMEOUT = 5000;
+var fs = require('fs');
+var path = require('path');
 
 module.exports = {
 

--- a/tests/example/.meteor/packages
+++ b/tests/example/.meteor/packages
@@ -10,3 +10,4 @@ mystor:device-detection
 accounts-password
 
 accounts-base
+iron:router

--- a/tests/example/.meteor/versions
+++ b/tests/example/.meteor/versions
@@ -22,6 +22,14 @@ htmljs@1.0.3
 http@1.0.10
 id-map@1.0.2
 insecure@1.0.2
+iron:controller@1.0.7
+iron:core@1.0.7
+iron:dynamic-template@1.0.7
+iron:layout@1.0.7
+iron:location@1.0.7
+iron:middleware-stack@1.0.7
+iron:router@1.0.7
+iron:url@1.0.7
 jquery@1.11.3
 json@1.0.2
 launch-screen@1.0.1

--- a/tests/example/example.html
+++ b/tests/example/example.html
@@ -14,13 +14,11 @@
   <p>You clicked {{counter}} times.</p>
 
 
-  <button id="waitForDOM">Adds element.</button>
+  <button id="waitForDOM">Click to add a new element.</button>
 
   <div id="waitUntilGone">
-    <div id="removeChildTestDiv">Removes element.</div>
+    <div id="removeChildTestDiv">Click to remove this element.</div>
   </div>
-
-  <div id="waitUntilNotVisible">Hides element.</div>
 
   <div id="getText"><h3>Get text.</h3></div>
 
@@ -31,13 +29,24 @@
 
   <input id="setValue" type="text">
 
-  <textarea id="focus" type="text">Focus element.</textarea>
-  <textarea id="blur" type="text">Blur element.</textarea>
+  <textarea id="focus" type="text">Click to focus this element.</textarea>
+  <textarea id="blur" type="text">Click in then out to blur this element.</textarea>
 
+  <!--checkIfVisible-->
   <div id="visibleElement">Visible Element.</div>
   <div id="hiddenElement" style="display:none">Hidden Element.</div>
   <div style="display:none"><ul><li id="hiddenChild"><p>Hidden Descendant.</p></li></ul></div>
   <div><ul><li><p id="visibleChild">Visible Descendant.</p></li></ul></div>
+  <div id="fixedPositionDiv" style="position:fixed;top:16px;right:0px;">Fixed position.</div>
+  <div id="absolutePositionDiv" style="position:absolute;top:0px;right:4px;">Absolute position.</div>
+  <div id="fixedPositionDivHidden" style="position:fixed;top:16px;right:0px;display:none;">Fixed position hidden.</div>
+  <div id="absolutePositionDivHidden" style="position:absolute;top:0px;right:4px;display:none;">Absolute position hidden.</div>
+  
+  <!--waitUntilNotVisible-->
+  <div id="waitUntilNotVisible">Click to hide this element.</div>
+  <button id="hideParentElement">Click to hide next div.</button>
+  <div id="waitUntilNotVisibleParent"><ul><li><p id="visibleChild2">Visible Descendant 2.</p></li></ul></div>
+
 </template>
 
 <template name="testRouteTemplate">

--- a/tests/example/example.html
+++ b/tests/example/example.html
@@ -31,5 +31,7 @@
 
   <input id="setValue" type="text">
 
+  <textarea id="focus" type="text">Focus element.</textarea>
+  <textarea id="blur" type="text">Blur element.</textarea>
 
 </template>

--- a/tests/example/example.html
+++ b/tests/example/example.html
@@ -12,4 +12,24 @@
   <input type="button" value="Click" />
   <input type="text"/>
   <p>You clicked {{counter}} times.</p>
+
+
+  <button id="waitForDOM">Adds element.</button>
+
+  <div id="waitUntilGone">
+    <div id="removeChildTestDiv">Removes element.</div>
+  </div>
+
+  <div id="waitUntilNotVisible">Hides element.</div>
+
+  <div id="getText"><h3>Get text.</h3></div>
+
+  <input id="getValue" type="text" value="Get value.">
+
+  <div id="getClass" class="myClass">Get class.</div>
+  <div id="noClass">Get class.</div>
+
+  <input id="setValue" type="text">
+
+
 </template>

--- a/tests/example/example.html
+++ b/tests/example/example.html
@@ -3,7 +3,7 @@
 </head>
 
 <body>
-  {{> hello}}
+  {{> yield}}
 </body>
 
 <template name="hello">
@@ -38,4 +38,8 @@
   <div id="hiddenElement" style="display:none">Hidden Element.</div>
   <div style="display:none"><ul><li id="hiddenChild"><p>Hidden Descendant.</p></li></ul></div>
   <div><ul><li><p id="visibleChild">Visible Descendant.</p></li></ul></div>
+</template>
+
+<template name="testRouteTemplate">
+  <div id="testRouteDiv"><h1>Testing Iron Router WaitForRoute Helper.</h1></div>
 </template>

--- a/tests/example/example.html
+++ b/tests/example/example.html
@@ -34,4 +34,8 @@
   <textarea id="focus" type="text">Focus element.</textarea>
   <textarea id="blur" type="text">Blur element.</textarea>
 
+  <div id="visibleElement">Visible Element.</div>
+  <div id="hiddenElement" style="display:none">Hidden Element.</div>
+  <div style="display:none"><ul><li id="hiddenChild"><p>Hidden Descendant.</p></li></ul></div>
+  <div><ul><li><p id="visibleChild">Visible Descendant.</p></li></ul></div>
 </template>

--- a/tests/example/example.js
+++ b/tests/example/example.js
@@ -8,13 +8,11 @@ if (Meteor.isClient) {
 
   Meteor.subscribe('items');
 
+
   Template.hello.helpers({
     greeting: function () {
       return "Welcome to example.";
-    }
-  });
-
-  Template.hello.helpers({
+    },
     counter: function () {
       return Session.get('counter');
     }
@@ -23,6 +21,21 @@ if (Meteor.isClient) {
   Template.hello.events({
     'click input': function () {
       Session.set('counter', Session.get('counter') + 1);
+    },
+    'click #waitForDOM' : function() {
+      var waitForTestDiv = document.createElement('div');
+      waitForTestDiv.id = 'waitForTestDiv';
+      waitForTestDiv.innerHTML = 'I have been added.';
+      document.body.appendChild(waitForTestDiv);
+    },
+    'click #waitUntilGone' : function() {
+      var parent = document.getElementById('waitUntilGone');
+      var child = document.getElementById('removeChildTestDiv');
+      parent.removeChild(child);
+    },
+    'click #waitUntilNotVisible' : function() {
+      var div = document.getElementById('waitUntilNotVisible');
+      div.style.display = "none";
     }
   });
 

--- a/tests/example/example.js
+++ b/tests/example/example.js
@@ -36,6 +36,12 @@ if (Meteor.isClient) {
     'click #waitUntilNotVisible' : function() {
       var div = document.getElementById('waitUntilNotVisible');
       div.style.display = "none";
+    },
+    'focus #focus' : function() {
+      document.getElementById('focus').value = 'Focused.';
+    },
+    'blur #blur' : function() {
+      document.getElementById('blur').value = 'Blurred.';
     }
   });
 

--- a/tests/example/example.js
+++ b/tests/example/example.js
@@ -2,6 +2,14 @@ Fiber = null;
 Items = new Meteor.Collection('items');
 reset = 0;
 
+Router.route('/', function () {
+  this.render('hello');
+});
+
+Router.route('/test', function () {
+  this.render('testRouteTemplate');
+});
+
 if (Meteor.isClient) {
 
   Session.set('counter', 0);

--- a/tests/example/example.js
+++ b/tests/example/example.js
@@ -30,22 +30,26 @@ if (Meteor.isClient) {
     'click input': function () {
       Session.set('counter', Session.get('counter') + 1);
     },
-    'click #waitForDOM' : function() {
+    'click #waitForDOM' : function () {
       var waitForTestDiv = document.createElement('div');
       waitForTestDiv.id = 'waitForTestDiv';
       waitForTestDiv.innerHTML = 'I have been added.';
       document.body.appendChild(waitForTestDiv);
     },
-    'click #waitUntilGone' : function() {
+    'click #waitUntilGone' : function () {
       var parent = document.getElementById('waitUntilGone');
       var child = document.getElementById('removeChildTestDiv');
       parent.removeChild(child);
     },
-    'click #waitUntilNotVisible' : function() {
+    'click #waitUntilNotVisible' : function () {
       var div = document.getElementById('waitUntilNotVisible');
       div.style.display = "none";
     },
-    'focus #focus' : function() {
+    'click #hideParentElement' : function () {
+      var div = document.getElementById('waitUntilNotVisibleParent');
+      div.style.display = "none";
+    },
+    'focus #focus' : function () {
       document.getElementById('focus').value = 'Focused.';
     },
     'blur #blur' : function() {

--- a/tests/specs/helpers.js
+++ b/tests/specs/helpers.js
@@ -2,7 +2,7 @@ var Promise = require('es6-promise').Promise;
 
 describe('Helpers', function () {
 
-  describe('Built in helpers', function () {
+  describe('Built in DOM helpers', function () {
 
     var server = meteor();
     var client = browser(server);
@@ -111,6 +111,66 @@ describe('Helpers', function () {
           expect(res).to.be.true;
         });
     });
+
+  });
+  
+  describe('Built in Accounts helpers', function () {
+    
+    var server = meteor();
+    var client = browser(server);
+
+    before(function () {
+      return server.execute(function () {
+        Accounts.createUser({email: 'existingUser@example.com',password: 'password'});
+      })    
+    });
+
+    it('signUp should create a new user with email option', function () {
+      return client
+        .signUp({email: 'test@example.com',password: 'password'})
+        .execute(function () {
+          return Meteor.users.findOne({'emails.address': 'test@example.com'});
+        })
+        .then(function(res) {
+          var email = res.emails[0].address;
+          expect(email).to.eql('test@example.com');
+        });
+    });
+
+    it('signUp should create a new user with username option', function () {
+      return client
+        .signUp({username: 'testName',password: 'password'})
+        .execute(function () {
+          return Meteor.users.findOne({username: 'testName'});
+        })
+        .then(function(res) {
+          expect(res.username).to.eql('testName');
+        });
+    });
+
+    it('login should login existing user', function () {
+      return client
+        .login('existingUser@example.com','password')
+        .execute(function () {
+          return Meteor.user();
+        })
+        .then(function(res) {
+          var email = res.emails[0].address;
+          expect(email).to.eql('existingUser@example.com');
+        });
+    });
+
+    it('logout should logout logged in user', function () {
+      return client
+        .logout()
+        .execute(function () {
+          return Meteor.user();
+        })
+        .then(function(res) {
+          expect(res).to.be.null;
+        });
+    });
+
 
   });
 

--- a/tests/specs/helpers.js
+++ b/tests/specs/helpers.js
@@ -87,6 +87,31 @@ describe('Helpers', function () {
         });
     });
 
+    it('focus should set focus on the given selector', function () {
+      return client
+        .focus('#focus')
+        .wait(1000,'until focused',function(el){
+          var element = document.querySelector('#focus');
+          return element.value==='Focused.';
+        })
+        .then(function(res) {
+          expect(res).to.be.true;
+        });
+    });
+
+    it('blur should set blur on the given selector', function () {
+      return client
+        .focus('#blur')
+        .blur('#blur')
+        .wait(1000,'until blurred',function(el){
+          var element = document.querySelector('#blur');
+          return element.value==='Blurred.';
+        })
+        .then(function(res) {
+          expect(res).to.be.true;
+        });
+    });
+
   });
 
   describe('Custom user-defined helpers', function () {

--- a/tests/specs/helpers.js
+++ b/tests/specs/helpers.js
@@ -174,6 +174,56 @@ describe('Helpers', function () {
 
   });
 
+  // TODO test afterFlush
+  describe.skip('Built in Tracker helpers', function () {
+    var server = meteor();
+    var client = browser(server);
+    it('afterFlush should schedule function for next flush', function () {
+      return client
+        .afterFlush()
+    });
+  });  
+
+  describe('Built in server connections helpers', function () {
+    var server = meteor();
+    var client = browser(server);
+    
+    it('should start in connected state.', function () {
+      return client
+        .execute(function () {
+          return Meteor.status();
+        })
+        .then(function(res) {
+          expect(res.status).to.eql('connected');
+          expect(res.connected).to.be.true;
+        })
+    });
+
+    it('disconnect client from the server.', function () {
+      return client
+        .disconnect()
+        .execute(function () {
+          return Meteor.status();
+        })
+        .then(function(res) {
+          expect(res.connected).to.be.false;
+        })
+    });
+
+    it('reconnect client to the server.', function () {
+      return client
+        .reconnect()
+        .execute(function () {
+          return Meteor.status();
+        })
+        .then(function(res) {
+          expect(res.status).to.eql('connected');
+          expect(res.connected).to.be.true;
+        })
+    });
+
+  }); 
+
   describe('Custom user-defined helpers', function () {
 
     var server = meteor({

--- a/tests/specs/helpers.js
+++ b/tests/specs/helpers.js
@@ -90,7 +90,7 @@ describe('Helpers', function () {
     it('focus should set focus on the given selector', function () {
       return client
         .focus('#focus')
-        .wait(1000,'until focused',function(el){
+        .wait(1000,'until focused',function(){
           var element = document.querySelector('#focus');
           return element.value==='Focused.';
         })
@@ -103,7 +103,7 @@ describe('Helpers', function () {
       return client
         .focus('#blur')
         .blur('#blur')
-        .wait(1000,'until blurred',function(el){
+        .wait(1000,'until blurred',function(){
           var element = document.querySelector('#blur');
           return element.value==='Blurred.';
         })

--- a/tests/specs/helpers.js
+++ b/tests/specs/helpers.js
@@ -242,6 +242,18 @@ describe('Helpers', function () {
     var server = meteor();
     var client = browser(server);
 
+    it('assertion helpers should work', function () {
+      return client
+        .expectExist('#visibleChild')
+        .expectNotExist('#noExist')
+        .expectVisible('#visibleChild')
+        .expectNotVisible('#hiddenChild')
+        .expectValueToEqual('#getValue','Get value.')
+        .expectTextToEqual('#getText','<h3>Get text.</h3>')
+        .expectTextToContain('#getText','Get tex')
+        .expectToHaveClass('#getClass','myClass')
+    });
+
     describe('checkIfExist', function () {
       it('should return true if element exists', function () {
         return client

--- a/tests/specs/helpers.js
+++ b/tests/specs/helpers.js
@@ -19,6 +19,74 @@ describe('Helpers', function () {
         .expectTextToContain('p', '1');
     });
 
+    it('waitForDOM should return true when dom object has been added', function () {
+      return client
+        .click('#waitForDOM')
+        .waitForDOM('#waitForTestDiv')
+        .then(function(res) {
+          expect(res).to.be.true;
+        });
+    });
+
+    it('waitUntilGone should return true when dom object has been removed', function () {
+      return client
+        .click('#waitUntilGone')
+        .waitUntilGone('#removeChildTestDiv')
+        .then(function(res) {
+          expect(res).to.be.true;
+        });
+    });
+
+    it('waitUntilNotVisible should return true when dom object is no longer visible', function () {
+      return client
+        .click('#waitUntilNotVisible')
+        .waitUntilNotVisible('#waitUntilNotVisible')
+        .then(function(res) {
+          expect(res).to.be.true;
+        });
+    });
+
+    it('getText should return innerHTML for a given selector', function () {
+      return client
+        .getText('#getText')
+        .then(function(res) {
+          expect(res).to.be.eql('<h3>Get text.</h3>');
+        });
+    });
+
+    it('getValue should return the value for a given selector', function () {
+      return client
+        .getValue('#getValue')
+        .then(function(res) {
+          expect(res).to.be.eql('Get value.');
+        });
+    });
+
+    it('getClass should return the classname for a given selector', function () {
+      return client
+        .getClass('#getClass')
+        .then(function(res) {
+          expect(res).to.be.eql('myClass');
+        });
+    });
+
+    it('getClass should return empty string if selector has no class', function () {
+      return client
+        .getClass('#noClass')
+        .then(function(res) {
+          expect(res).to.be.eql('');
+        });
+    });
+
+    it('setValue should set the value of an input', function () {
+      return client
+        .setValue('#setValue','test value')
+        .getValue('#setValue')
+        .then(function(res) {
+          expect(res).to.be.eql('test value');
+        });
+    });
+
   });
 
   describe('Custom user-defined helpers', function () {

--- a/tests/specs/helpers.js
+++ b/tests/specs/helpers.js
@@ -114,6 +114,44 @@ describe('Helpers', function () {
 
   });
   
+  describe('waitForRoute', function () {
+
+    var server = meteor();
+    var client = browser(server);
+
+    it('should change the route and load correct template', function () {
+      return client
+        .waitForRoute('/test')
+        .waitForDOM('#testRouteDiv')
+        .getText('#testRouteDiv')
+        .then(function(res) {
+          expect(res).to.contain('Testing Iron Router');
+        });
+    });
+
+    it('should be ok if routing to the current route', function () {
+      return client
+        .waitForRoute('/test')  
+        .getText('#testRouteDiv')  // we shouldn't need to waitForDOM here
+        .then(function(res) {
+          expect(res).to.contain('Testing Iron Router');
+        });
+    });
+
+    it('should be ok returning to previous route', function () {
+      return client
+        .waitForRoute('/')
+        .waitForDOM('#getText')
+    });
+
+    it('should work with a specified timeout', function () {
+      return client
+        .waitForRoute('/test',3000)
+        .waitForDOM('#testRouteDiv')
+    });
+
+  });
+
   describe('Built in Accounts helpers', function () {
     
     var server = meteor();

--- a/tests/specs/helpers.js
+++ b/tests/specs/helpers.js
@@ -238,6 +238,70 @@ describe('Helpers', function () {
     });
   });
 
+  describe('helper assertions', function () {
+    var server = meteor();
+    var client = browser(server);
+
+    describe('checkIfExist', function () {
+      it('should return true if element exists', function () {
+        return client
+          .checkIfExist('#visibleElement')
+          .then(function(res) {
+            expect(res).to.be.true;
+          })
+      });
+
+      it('should return false if element does not exist', function () {
+        return client
+          .checkIfExist('#noExist')
+          .then(function(res) {
+            expect(res).to.be.false;
+          })
+      });
+    });
+
+    describe('checkIfVisible ', function () {
+      it('should return true if element is visible', function () {
+        return client
+          .checkIfVisible('#visibleElement')
+          .then(function(res) {
+            expect(res).to.be.true;
+          })
+      });
+
+      it('should return true if element and ancestors are visible', function () {
+        return client
+          .checkIfVisible('#visibleChild')
+          .then(function(res) {
+            expect(res).to.be.true;
+          })
+      });
+
+      it('should return false if element does not exist', function () {
+        return client
+          .checkIfVisible('#noExist')
+          .then(function(res) {
+            expect(res).to.be.false;
+          })
+      });
+
+      it('should return false if element is not visible', function () {
+        return client
+          .checkIfVisible('#hiddenElement')
+          .then(function(res) {
+            expect(res).to.be.false;
+          })
+      });
+
+      it('should return false if any ancestors are not visible', function () {
+        return client
+          .checkIfVisible('#hiddenChild')
+          .then(function(res) {
+            expect(res).to.be.false;
+          })
+      });
+    });
+  });
 
   describe('Custom user-defined helpers', function () {
 

--- a/tests/specs/helpers.js
+++ b/tests/specs/helpers.js
@@ -46,6 +46,15 @@ describe('Helpers', function () {
         });
     });
 
+    it('waitUntilNotVisible should return true when dom object ancestor no longer visible', function () {
+      return client
+        .click('#hideParentElement')
+        .waitUntilNotVisible('#visibleChild2')
+        .then(function(res) {
+          expect(res).to.be.true;
+        });
+    });
+
     it('getText should return innerHTML for a given selector', function () {
       return client
         .getText('#getText')
@@ -346,6 +355,15 @@ describe('Helpers', function () {
             expect(res).to.be.false;
           })
       });
+
+      it('should work for fixed and absolute position elements', function () {
+        return client
+          .expectVisible('#fixedPositionDiv')
+          .expectVisible('#absolutePositionDiv')
+          .expectNotVisible('#fixedPositionDivHidden')
+          .expectNotVisible('#absolutePositionDivHidden')
+      });
+
     });
   });
 

--- a/tests/specs/helpers.js
+++ b/tests/specs/helpers.js
@@ -226,14 +226,10 @@ describe('Helpers', function () {
     var server = meteor();
     var client = browser(server);
     
-    it('should start in connected state.', function () {
+    it('start in connected state.', function () {
       return client
-        .execute(function () {
-          return Meteor.status();
-        })
-        .then(function(res) {
-          expect(res.status).to.eql('connected');
-          expect(res.connected).to.be.true;
+        .wait(3000,'until connected',function(){
+          return Meteor.status().connected===true;
         })
     });
 

--- a/tests/specs/helpers.js
+++ b/tests/specs/helpers.js
@@ -224,6 +224,21 @@ describe('Helpers', function () {
 
   }); 
 
+  //TODO where to put screenshot file for this test ? 
+  describe.skip('screenshot', function () {
+    var server = meteor();
+    var client = browser(server);
+
+    it('should save a screenshot to file.', function () {
+      return client
+        .screenshot()
+        .then(function(res) {
+          //assert file exists and is named by today's date and has some bytes
+        })
+    });
+  });
+
+
   describe('Custom user-defined helpers', function () {
 
     var server = meteor({


### PR DESCRIPTION
ticket #24 
tests for Browser Helpers

I tried to test things in isolation, however in some cases parts of the framework are used to test itself.  
For example, using the click() helper makes the test a lot cleaner to add and remove dom elements, rather than putting setTimeouts littered throughout the Example application code.  But it means there are interdependencies within this suite, so a failure in a single case may represent a failure in its dependency.  I have some ideas how to address this if its a problem.

I added Iron Router to the Example app.  waitForRoute() was actually pretty easy to test for, as long as it's okay to have some interdependencies as described above.

pending : 
- screenshot
I can observe this working, but I don't know where to store the file, and how to clean up the file when it's done?
- afterFlush
it seems like this helper should take a function as its argument?  
I kept both these test cases in and am skipping them for now.
maybe we can open a separate ticket for each of these?  Or we can try to fix in this PR review.

