### PR TITLE
add meteor binary file extension (.bat) for Windows

### DIFF
--- a/lib/meteor/build.js
+++ b/lib/meteor/build.js
@@ -126,7 +126,8 @@ function BuildPromise(options) {
 
     var buildTimeout = null;
 
-    var meteor = spawn('meteor', args, {
+    var meteorBinary = tools.getMeteorBinary();
+    var meteor = spawn(meteorBinary, args, {
       cwd: pathToApp, env: env, stdio: verbose ? 'inherit' : 'ignore'
     });
 

--- a/lib/tools/index.js
+++ b/lib/tools/index.js
@@ -119,6 +119,25 @@ module.exports = {
       });
   }),
 
+  getMeteorBinary: _.memoize(function () {
+    "use strict";
+
+    // Windows may require an extension when spawning executable files,
+    // all known other platforms don't.
+    if (process.platform !== 'win32')
+      return 'meteor';
+
+    // Meteor for Windows is a .bat file, living in AppData/Local/.meteor check
+    // if it exists, or return without extension to try .exe fallback. Just in
+    // case MDG might decide to provide an exe instead of bat file in future versions.
+    // see https://github.com/meteor/windows-preview/issues/73#issuecomment-76873375
+    var meteorPath = path.join(process.env.LOCALAPPDATA, '.meteor');
+    if (fs.existsSync(path.join(meteorPath, 'meteor.bat')))
+      return 'meteor.bat';
+
+    return 'meteor';
+  }),
+
   getUserHome: function () {
     "use strict";
 


### PR DESCRIPTION
Add's the `.bat` file extension to the meteor binary file in case we're running on a Windows platform. This is because node `spawn` on Windows requires an file extension, unless it's spawning an `.exe` file (*meteor is a .bat file*)

The check for existence of `meteor.bat` is to be able to provide some kind of fallback to a `.exe` (extensionless) variant in case MDG decides to create some `.exe` wrapper for Windows. There once was [a discussion](https://github.com/meteor/windows-preview/issues/73#issuecomment-76873375)  about that matter.

See also https://github.com/anticoders/gagarin/issues/126#issuecomment-98361568 for this pull-request.

`getMeteorBinary` could be extended in time, as newer Meteor versions might require.