### PR TITLE
get non-zero exit code even if no cleanup required

### DIFF
--- a/bin/gagarin
+++ b/bin/gagarin
@@ -89,10 +89,10 @@ files.forEach(function (file) {
 process.stdout.write(chalk.green('\n  added ' + files.length + ' test files ...\n\n'));
 
 gagarin.run(function (failedCount) {
-  process.emit('cleanup');
   process.once('clean', function () {
     process.exit(failedCount > 0 ? 1 : 0);
   });
+  process.emit('cleanup');
 });
 
 function parse10(v) {


### PR DESCRIPTION
gagarin exit code is incorrectly 0 for failing tests without cleanup tasks, e.g.

```javascript
describe("A FAST failing TEST", function() {

    it("fails", function() {
        expect(1).to.equal(2);
    });
});
```
this is before the once('clean') handler is registered after the clean event is emitted.