### PR TITLE
click, wait: include original call stack in error message

### DIFF
--- a/lib/browser/helpers.js
+++ b/lib/browser/helpers.js
@@ -113,14 +113,19 @@ module.exports = {
   },
 
   click: function (selector, keys) {
+    var self = this;
+    var origCaller = new Error("at");
+
     return this.__custom__(function (operand, done) {
       operand.browser.elementByCssSelectorOrNull(selector, done);
     }).then(function (element) {
       if (!element) {
-        throw new Error('element ' + selector + ' does not exists');
+        self.throwWithMessage('element ' + selector + ' does not exists', origCaller);
       }
       return new Promise(function (resolve, reject) {
-        element.click(either(reject).or(resolve));
+        element.click(either(
+          self.rejectWithMessage('clickError(' + selector + ', ' + keys + ')', origCaller, reject)
+        ).or(resolve));
       });
     });
   },

--- a/lib/browser/methods.js
+++ b/lib/browser/methods.js
@@ -4,6 +4,25 @@ var fs         = require('fs');
 
 module.exports = {};
 
+module.exports.rejectWithMessage = function(message, origCaller, reject) {
+  "use strict";
+
+  return function(err){
+    var stack = String(origCaller.stack);
+    stack = stack.substring(stack.indexOf('\n', stack.indexOf('\n') + 1) + 1);
+    reject(new Error(message + ' ' + err + '\n' + stack));
+  };
+};
+
+module.exports.throwWithMessage = function(message, err) {
+  "use strict";
+
+  var stack = String(err.stack);
+  stack = stack.substring(stack.indexOf('\n', stack.indexOf('\n') + 1) + 1);
+
+  throw new Error(message + '\n' + stack);
+};
+
 module.exports.execute = function (code, args) {
   "use strict";
 
@@ -155,6 +174,7 @@ module.exports.wait = function (timeout, message, code, args) {
   }
 
   var self = this;
+  var origCaller = new Error("at");
 
   return self.__custom__(function (operand, done) {
     
@@ -223,7 +243,7 @@ module.exports.wait = function (timeout, message, code, args) {
       // retry after reparing the problem
       return retry(function (operand, done) { loadChai(operand.browser, done) });
     }
-    throw err;
+    self.throwWithMessage("waitError("+err.message+")", origCaller);
   });
 
 };


### PR DESCRIPTION
When calling click() or waitForDom, I've included the original call stack in the error message.
With this I can figure out which of the waitForDom failed, even if there is the same selector.
Same thing for click(), where I sometime get errors in the element.click() code, which doesn't show which selector it was.

You see the waitForDom("#signIn") message  here in action:
```
1) some test should do something:
     Error: waitError(I have been waiting for 10000 ms until element #signIn is present, but it did not happen.)
  at Object.module.exports.waitForDOM (/usr/local/lib/node_modules/gagarin/lib/browser/helpers.js:31:17)
  at /Users/eric/W/app/tests/gagarin/connect/disconnect_twice.js:180:14
  at /usr/local/lib/node_modules/gagarin/lib/mocha/interface.js:361:27

    at Object.module.exports.throwWithMessage (/usr/local/lib/node_modules/gagarin/lib/browser/methods.js:23:9)
    at /usr/local/lib/node_modules/gagarin/lib/browser/methods.js:246:10
    at /usr/local/lib/node_modules/gagarin/lib/tools/genericPromiseChain.js:187:15
    at /usr/local/lib/node_modules/gagarin/lib/tools/index.js:165:25
    at /usr/local/lib/node_modules/gagarin/lib/browser/index.js:84:11
    at /usr/local/lib/node_modules/gagarin/lib/browser/methods.js:303:14
    at cb (/usr/local/lib/node_modules/gagarin/node_modules/wd/lib/webdriver.js:221:45)
    at /usr/local/lib/node_modules/gagarin/node_modules/wd/lib/callbacks.js:105:5
    at /usr/local/lib/node_modules/gagarin/node_modules/wd/lib/callbacks.js:82:7
    at /usr/local/lib/node_modules/gagarin/node_modules/wd/lib/webdriver.js:174:5
    at Request._callback (/usr/local/lib/node_modules/gagarin/node_modules/wd/lib/http-utils.js:87:7)
    at Request.self.callback (/usr/local/lib/node_modules/gagarin/node_modules/wd/node_modules/request/request.js:368:22)
    at emitTwo (events.js:87:13)
    at Request.emit (events.js:172:7)
    at Request.<anonymous> (/usr/local/lib/node_modules/gagarin/node_modules/wd/node_modules/request/request.js:1219:14)
    at emitOne (events.js:82:20)
    at Request.emit (events.js:169:7)
    at IncomingMessage.<anonymous> (/usr/local/lib/node_modules/gagarin/node_modules/wd/node_modules/request/request.js:1167:12)
    at emitNone (events.js:72:20)
    at IncomingMessage.emit (events.js:166:7)
    at endReadableNT (_stream_readable.js:893:12)
    at doNTCallback2 (node.js:429:9)
    at process._tickCallback (node.js:343:17)
```
compared to what I get with the original code:
```
1) some test should do something:
     Error: waitError(I have been waiting for 10000 ms until element #signIn is present, but it did not happen.)
    at Object.module.exports.throwWithMessage (/usr/local/lib/node_modules/gagarin/lib/browser/methods.js:23:9)
    at /usr/local/lib/node_modules/gagarin/lib/browser/methods.js:246:10
    at /usr/local/lib/node_modules/gagarin/lib/tools/genericPromiseChain.js:187:15
    at /usr/local/lib/node_modules/gagarin/lib/tools/index.js:165:25
    at /usr/local/lib/node_modules/gagarin/lib/browser/index.js:84:11
    at /usr/local/lib/node_modules/gagarin/lib/browser/methods.js:303:14
    at cb (/usr/local/lib/node_modules/gagarin/node_modules/wd/lib/webdriver.js:221:45)
    at /usr/local/lib/node_modules/gagarin/node_modules/wd/lib/callbacks.js:105:5
    at /usr/local/lib/node_modules/gagarin/node_modules/wd/lib/callbacks.js:82:7
    at /usr/local/lib/node_modules/gagarin/node_modules/wd/lib/webdriver.js:174:5
    at Request._callback (/usr/local/lib/node_modules/gagarin/node_modules/wd/lib/http-utils.js:87:7)
    at Request.self.callback (/usr/local/lib/node_modules/gagarin/node_modules/wd/node_modules/request/request.js:368:22)
    at emitTwo (events.js:87:13)
    at Request.emit (events.js:172:7)
    at Request.<anonymous> (/usr/local/lib/node_modules/gagarin/node_modules/wd/node_modules/request/request.js:1219:14)
    at emitOne (events.js:82:20)
    at Request.emit (events.js:169:7)
    at IncomingMessage.<anonymous> (/usr/local/lib/node_modules/gagarin/node_modules/wd/node_modules/request/request.js:1167:12)
    at emitNone (events.js:72:20)
    at IncomingMessage.emit (events.js:166:7)
    at endReadableNT (_stream_readable.js:893:12)
    at doNTCallback2 (node.js:429:9)
    at process._tickCallback (node.js:343:17)
```