### PR TITLE
add NODE_PATH instead of symlink, atm only for windows

### DIFF
--- a/lib/meteor/linkNodeModules.js
+++ b/lib/meteor/linkNodeModules.js
@@ -46,6 +46,15 @@ module.exports = function linkNodeModules (pathToApp) {
       }
 
       function createSymlink(from, to) {
+        // Don't create symlink in case of Windows platforms. Symlink creation
+        // requires administrator rights. Besides, Windows can use the NODE_PATH
+        // variable so symlinks aren't required. We should check if this can also
+        // work for linux / macos. See NODE_PATH in meteorProcessManager/getMeteorProcess
+        if (process.platform === 'win32') {
+          return resolve();
+        }
+
+        // all other platforms create symlinks
         fs.symlink(from, path.join(to, 'node_modules'), function (err) {
           if (err) {
             if (err.code === 'EEXIST') {

--- a/lib/meteor/meteorProcessManager.js
+++ b/lib/meteor/meteorProcessManager.js
@@ -5,6 +5,7 @@ var Promise             = require('es6-promise').Promise;
 var chalk               = require('chalk');
 var logs                = require('../logs');
 var tools               = require('../tools');
+var path                = require('path');
 
 module.exports = function createMeteorProcessManager (options) {
   "use strict";
@@ -90,6 +91,7 @@ module.exports = function createMeteorProcessManager (options) {
           env.MONGO_URL        = mongoUrl;
           env.GAGARIN_SETTINGS = "{}"; // only used if METEOR_SETTINGS does not contain gagarin field
           env.NODE_ENV         = "development";
+          env.NODE_PATH        = path.join(pathToNode.split('dev_bundle')[0], 'dev_bundle', 'server-lib', 'node_modules');
 
           setTimeout(function () {
             meteorProcess = new createMeteorProcess(pathToNode, pathToMain, env, meteorProcessPrototype, options);


### PR DESCRIPTION
Fixes #128.

> **Find workaround for symlinks on windows platform**
> .. because we don't want to force users to run within the administrator console.
> A detailed explanation of the problem can be found here:
>
> https://github.com/anticoders/gagarin/issues/126#issuecomment-98474099