### PR TITLE
give access to node modules in server test code

### DIFF
--- a/meteor/backdoor.js
+++ b/meteor/backdoor.js
@@ -21,6 +21,7 @@ if (Gagarin.isActive) {
         return function (arg1, arg2) { return arg1 ? first(arg1) : second(arg2) };
     }};
   };
+  plugins.Npm = Npm;
 
   // TODO: also protect these methods with some authentication (user/password/token?)
   //       note that required data my be provided with GAGARIN_SETTINGS


### PR DESCRIPTION
By giving access to the Npm object in server `backdoor.js`, one can require base node modules, like `http`.

This fixes #181. With it I can test my API endpoint by querying it from the server.
